### PR TITLE
Remove code until it compiles to find cause of Secret contract deployment error

### DIFF
--- a/packages/secret-contracts/nunya-contract/.cargo/config.toml
+++ b/packages/secret-contracts/nunya-contract/.cargo/config.toml
@@ -1,3 +1,7 @@
 [alias]
-unit-test = "test --lib --features backtraces"
-schema = "run --example schema"
+# Temporarily removed the backtraces feature from the unit-test run due to compilation errors in
+# the cosmwasm-std package:
+# cosmwasm-std = { git = "https://github.com/scrtlabs/cosmwasm", branch = "secret" }
+# unit-test = "test --lib --features backtraces"
+unit-test = "test --lib"
+schema = "run --bin schema --features schema"

--- a/packages/secret-contracts/nunya-contract/node/upload.js
+++ b/packages/secret-contracts/nunya-contract/node/upload.js
@@ -1,101 +1,101 @@
-import { SecretNetworkClient, Wallet, coinsFromString } from "secretjs";
-import * as fs from "fs";
-import dotenv from "dotenv";
-dotenv.config();
+// import { SecretNetworkClient, Wallet, coinsFromString } from "secretjs";
+// import * as fs from "fs";
+// import dotenv from "dotenv";
+// dotenv.config();
 
-const wallet = new Wallet(process.env.MNEMONIC);
+// const wallet = new Wallet(process.env.MNEMONIC);
 
-const contract_wasm = fs.readFileSync("../contract.wasm.gz");
+// const contract_wasm = fs.readFileSync("../contract.wasm.gz");
 
-const gatewayAddress = "secret10ex7r7c4y704xyu086lf74ymhrqhypayfk7fkj";
+// const gatewayAddress = "secret10ex7r7c4y704xyu086lf74ymhrqhypayfk7fkj";
 
-const gatewayHash =
-  "012dd8efab9526dec294b6898c812ef6f6ad853e32172788f54ef3c305c1ecc5";
+// const gatewayHash =
+//   "012dd8efab9526dec294b6898c812ef6f6ad853e32172788f54ef3c305c1ecc5";
 
-const gatewayPublicKey =
-  "0x046d0aac3ef10e69055e934ca899f508ba516832dc74aa4ed4d741052ed5a568774d99d3bfed641a7935ae73aac8e34938db747c2f0e8b2aa95c25d069a575cc8b";
+// const gatewayPublicKey =
+//   "0x046d0aac3ef10e69055e934ca899f508ba516832dc74aa4ed4d741052ed5a568774d99d3bfed641a7935ae73aac8e34938db747c2f0e8b2aa95c25d069a575cc8b";
 
-const gatewayPublicKeyBytes = Buffer.from(
-  gatewayPublicKey.substring(2),
-  "hex"
-).toString("base64");
+// const gatewayPublicKeyBytes = Buffer.from(
+//   gatewayPublicKey.substring(2),
+//   "hex"
+// ).toString("base64");
 
-const secretjs = new SecretNetworkClient({
-  chainId: "pulsar-3",
-  url: "https://api.pulsar3.scrttestnet.com",
-  wallet: wallet,
-  walletAddress: wallet.address,
-});
+// const secretjs = new SecretNetworkClient({
+//   chainId: "pulsar-3",
+//   url: "https://api.pulsar3.scrttestnet.com",
+//   wallet: wallet,
+//   walletAddress: wallet.address,
+// });
 
-// Declare global variables
-let codeId;
-let contractCodeHash;
-let contractAddress;
+// // Declare global variables
+// let codeId;
+// let contractCodeHash;
+// let contractAddress;
 
-let upload_contract = async () => {
-  console.log("Starting deployment…");
+// let upload_contract = async () => {
+//   console.log("Starting deployment…");
 
-  let tx = await secretjs.tx.compute.storeCode(
-    {
-      sender: wallet.address,
-      wasm_byte_code: contract_wasm,
-      source: "",
-      builder: "",
-    },
-    {
-      gasLimit: 4_000_000,
-    }
-  );
+//   let tx = await secretjs.tx.compute.storeCode(
+//     {
+//       sender: wallet.address,
+//       wasm_byte_code: contract_wasm,
+//       source: "",
+//       builder: "",
+//     },
+//     {
+//       gasLimit: 4_000_000,
+//     }
+//   );
 
-  codeId = Number(
-    tx.arrayLog.find((log) => log.type === "message" && log.key === "code_id")
-      .value
-  );
-  console.log("codeId: ", codeId);
+//   codeId = Number(
+//     tx.arrayLog.find((log) => log.type === "message" && log.key === "code_id")
+//       .value
+//   );
+//   console.log("codeId: ", codeId);
 
-  contractCodeHash = (
-    await secretjs.query.compute.codeHashByCodeId({ code_id: codeId })
-  ).code_hash;
-  console.log(`CODE_HASH: ${contractCodeHash}`);
-};
+//   contractCodeHash = (
+//     await secretjs.query.compute.codeHashByCodeId({ code_id: codeId })
+//   ).code_hash;
+//   console.log(`CODE_HASH: ${contractCodeHash}`);
+// };
 
-let instantiate_contract = async () => {
-  if (!codeId || !contractCodeHash) {
-    throw new Error("codeId or contractCodeHash is not set.");
-  }
-  console.log("Instantiating contract…");
+// let instantiate_contract = async () => {
+//   if (!codeId || !contractCodeHash) {
+//     throw new Error("codeId or contractCodeHash is not set.");
+//   }
+//   console.log("Instantiating contract…");
 
-  let init = {
-    gateway_address: gatewayAddress,
-    gateway_hash: gatewayHash,
-    gateway_key: gatewayPublicKeyBytes,
-  };
-  let tx = await secretjs.tx.compute.instantiateContract(
-    {
-      code_id: codeId,
-      sender: wallet.address,
-      code_hash: contractCodeHash,
-      init_msg: init,
-      label: "SnakePath Encrypt " + Math.ceil(Math.random() * 10000),
-    },
-    {
-      gasLimit: 400_000,
-    }
-  );
+//   let init = {
+//     gateway_address: gatewayAddress,
+//     gateway_hash: gatewayHash,
+//     gateway_key: gatewayPublicKeyBytes,
+//   };
+//   let tx = await secretjs.tx.compute.instantiateContract(
+//     {
+//       code_id: codeId,
+//       sender: wallet.address,
+//       code_hash: contractCodeHash,
+//       init_msg: init,
+//       label: "SnakePath Encrypt " + Math.ceil(Math.random() * 10000),
+//     },
+//     {
+//       gasLimit: 400_000,
+//     }
+//   );
 
-  //Find the contract_address in the logs
-  const contractAddress = tx.arrayLog.find(
-    (log) => log.type === "message" && log.key === "contract_address"
-  ).value;
+//   //Find the contract_address in the logs
+//   const contractAddress = tx.arrayLog.find(
+//     (log) => log.type === "message" && log.key === "contract_address"
+//   ).value;
 
-  console.log("SECRET_ADDRESS: ", contractAddress);
-};
+//   console.log("SECRET_ADDRESS: ", contractAddress);
+// };
 
-// Chain the execution using promises
-upload_contract()
-  .then(() => {
-    instantiate_contract();
-  })
-  .catch((error) => {
-    console.error("Error:", error);
-  });
+// // Chain the execution using promises
+// upload_contract()
+//   .then(() => {
+//     instantiate_contract();
+//   })
+//   .catch((error) => {
+//     console.error("Error:", error);
+//   });

--- a/packages/secret-contracts/nunya-contract/src/contract.rs
+++ b/packages/secret-contracts/nunya-contract/src/contract.rs
@@ -5,12 +5,12 @@ use crate::{
         // NewAuthOutStoreMsg, LinkPaymentRefStoreMsg, PayStoreMsg, WithdrawToStoreMsg,
         // ResponseNewAuthOutStoreMsg, ResponseLinkPaymentRefStoreMsg, ResponsePayStoreMsg, ResponseWithdrawToStoreMsg, ResponseRetrievePubkeyMsg,
     },
-    state::{
-        // PaymentReceipt, PaymentReferenceBalance, ResponseStatusCode,
-        State, CONFIG,
-        // MY_KEYS,
-        // VIEWING_KEY, VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP,
-    },
+    // state::{
+    //     // PaymentReceipt, PaymentReferenceBalance, ResponseStatusCode,
+    //     State, CONFIG,
+    //     // MY_KEYS,
+    //     // VIEWING_KEY, VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP,
+    // },
 };
 use cosmwasm_std::{
     entry_point, to_binary, coin, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128, Uint256
@@ -33,14 +33,14 @@ pub fn instantiate(
     _info: MessageInfo,
     msg: InstantiateMsg,
 ) -> StdResult<Response> {
-    // Initialise state
-    let state = State {
-        gateway_address: msg.gateway_address,
-        gateway_hash: msg.gateway_hash,
-        gateway_key: msg.gateway_key,
-    };
+    // // Initialise state
+    // let state = State {
+    //     gateway_address: msg.gateway_address,
+    //     gateway_hash: msg.gateway_hash,
+    //     gateway_key: msg.gateway_key,
+    // };
 
-    CONFIG.save(deps.storage, &state)?;
+    // CONFIG.save(deps.storage, &state)?;
 
     Ok(Response::default())
 }
@@ -61,7 +61,7 @@ fn try_handle(
     msg: PrivContractHandleMsg,
 ) -> StdResult<Response> {
     // verify signature with stored gateway public key
-    let config = CONFIG.load(deps.storage)?;
+    // let config = CONFIG.load(deps.storage)?;
 
     // // Security
     // //
@@ -72,13 +72,13 @@ fn try_handle(
     //     ));
     // }
 
-    deps.api
-        .secp256k1_verify(
-            msg.input_hash.as_slice(),
-            msg.signature.as_slice(),
-            config.gateway_key.as_slice(),
-        )
-        .map_err(|err| StdError::generic_err(err.to_string()))?;
+    // deps.api
+    //     .secp256k1_verify(
+    //         msg.input_hash.as_slice(),
+    //         msg.signature.as_slice(),
+    //         config.gateway_key.as_slice(),
+    //     )
+    //     .map_err(|err| StdError::generic_err(err.to_string()))?;
 
     // determine which function to call based on the included handle
     let handle = msg.handle.as_str();

--- a/packages/secret-contracts/nunya-contract/src/contract.rs
+++ b/packages/secret-contracts/nunya-contract/src/contract.rs
@@ -1,13 +1,15 @@
 use crate::{
     msg::{
-        ExecuteMsg, GatewayMsg, InstantiateMsg, QueryMsg,
-        NewAuthOutStoreMsg, LinkPaymentRefStoreMsg, PayStoreMsg, WithdrawToStoreMsg,
-        ResponseNewAuthOutStoreMsg, ResponseLinkPaymentRefStoreMsg, ResponsePayStoreMsg, ResponseWithdrawToStoreMsg, ResponseRetrievePubkeyMsg,
+        ExecuteMsg, InstantiateMsg,
+        // GatewayMsg, QueryMsg,
+        // NewAuthOutStoreMsg, LinkPaymentRefStoreMsg, PayStoreMsg, WithdrawToStoreMsg,
+        // ResponseNewAuthOutStoreMsg, ResponseLinkPaymentRefStoreMsg, ResponsePayStoreMsg, ResponseWithdrawToStoreMsg, ResponseRetrievePubkeyMsg,
     },
     state::{
-        PaymentReceipt, PaymentReferenceBalance, ResponseStatusCode,
-        State, CONFIG, MY_KEYS,
-        VIEWING_KEY, VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP,
+        // PaymentReceipt, PaymentReferenceBalance, ResponseStatusCode,
+        State, CONFIG,
+        // MY_KEYS,
+        // VIEWING_KEY, VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP,
     },
 };
 use cosmwasm_std::{
@@ -61,14 +63,14 @@ fn try_handle(
     // verify signature with stored gateway public key
     let config = CONFIG.load(deps.storage)?;
 
-    // Security
-    //
-    // reference: evm-kv-store-demo
-    if info.sender != config.gateway_address {
-        return Err(StdError::generic_err(
-            "Only SecretPath Gateway can call this function",
-        ));
-    }
+    // // Security
+    // //
+    // // reference: evm-kv-store-demo
+    // if info.sender != config.gateway_address {
+    //     return Err(StdError::generic_err(
+    //         "Only SecretPath Gateway can call this function",
+    //     ));
+    // }
 
     deps.api
         .secp256k1_verify(
@@ -81,524 +83,524 @@ fn try_handle(
     // determine which function to call based on the included handle
     let handle = msg.handle.as_str();
     match handle {
-        "newSecretUser" => create_new_auth_out(deps, env, info, msg.input_values, msg.task, msg.input_hash),
-        "createPaymentReference" => create_payment_reference(deps, env, msg.input_values, msg.task, msg.input_hash),
-        // handle both `pay` and `payWithReceipt` Solidity function calls using the same `create_pay` Secret contract function
-        "pay" => create_pay(deps, env, msg.input_values, msg.task, msg.input_hash),
-        "payWithReceipt" => create_pay(deps, env, msg.input_values, msg.task, msg.input_hash),
-        "withdrawTo" => create_withdraw_to(deps, env, msg.input_values, msg.task, msg.input_hash),
+        // "newSecretUser" => create_new_auth_out(deps, env, info, msg.input_values, msg.task, msg.input_hash),
+        // "createPaymentReference" => create_payment_reference(deps, env, msg.input_values, msg.task, msg.input_hash),
+        // // handle both `pay` and `payWithReceipt` Solidity function calls using the same `create_pay` Secret contract function
+        // "pay" => create_pay(deps, env, msg.input_values, msg.task, msg.input_hash),
+        // "payWithReceipt" => create_pay(deps, env, msg.input_values, msg.task, msg.input_hash),
+        // "withdrawTo" => create_withdraw_to(deps, env, msg.input_values, msg.task, msg.input_hash),
 
         _ => Err(StdError::generic_err("invalid handle".to_string())),
     }
 }
 
-fn create_new_auth_out(
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    input_values: String,
-    task: Task,
-    input_hash: Binary,
-) -> StdResult<Response> {
-    let config = CONFIG.load(deps.storage)?;
-
-    let input: NewAuthOutStoreMsg = serde_json_wasm::from_str(&input_values)
-        .map_err(|err| StdError::generic_err(err.to_string()))?;
-
-    let viewing_key_index = input.secret_user.as_str(); // convert u8 to String
-
-    if viewing_key_index.chars().count() == 0 {
-        return Err(StdError::generic_err("Secret must not be an empty string"));
-    }
-
-    // https://docs.scrt.network/secret-network-documentation/development/development-concepts/permissioned-viewing/viewing-keys#viewing-keys-implementation
-    let gateway_account = config.gateway_address.to_owned();
-    let mut index_concat: String = gateway_account.to_string();
-    let suffix: &str = viewing_key_index;
-    // mutate in place https://stackoverflow.com/a/30154791/3208553
-    index_concat.push_str(suffix);
-
-    // https://docs.scrt.network/secret-network-documentation/development/development-concepts/permissioned-viewing/viewing-keys#viewing-keys-introduction
-    // https://github.com/scrtlabs/examples/blob/master/secret-viewing-keys/secret-viewing-keys-contract/src/contract.rs
-    let entropy: &[u8] = b"entropy";
-    let viewing_key = ViewingKey::create(deps.storage, &info, &env, gateway_account.as_str(), entropy);
-
-    // Viewing Key
-    VIEWING_KEY
-        // TODO - sender is always the gateway contract, or perhaps change this to `info.sender.as_bytes()`
-        .add_suffix(config.gateway_address.as_bytes())
-        .insert(deps.storage, &viewing_key_index.to_string(), &viewing_key)?;
-
-    // Attempt to retrieve existing
-    let value_payment_reference_to_balances_map: Option<Vec<PaymentReferenceBalance>> = Some(VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP
-        .get(deps.storage, &index_concat)
-        .ok_or_else(|| StdError::generic_err("Value for this VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP key not found"))?);
-
-    // TODO: need to setup viewing key for the mapping, but not necessary to store this example
-    let init_balance: Coin = coin(0u128, String::new());
-    let init_payment_ref = String::new();
-    let init_payment_reference_balance = PaymentReferenceBalance {
-        payment_reference: init_payment_ref,
-        balance: init_balance,
-    };
-
-    let mut value_payment_reference_to_balances: Vec<PaymentReferenceBalance> = match value_payment_reference_to_balances_map {
-        Some(payment_reference_to_balances) => payment_reference_to_balances, // If there are existing
-        None => Vec::new(),   // If none are found, start with an empty vector
-    };
-
-    // Add the new to vector
-    value_payment_reference_to_balances.push(init_payment_reference_balance.clone());
-
-    // Save updated back to storage
-    VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP
-        .insert(deps.storage, &viewing_key, &value_payment_reference_to_balances)?;
-
-    let response_status_code: ResponseStatusCode = 0u16;
-
-    let data = ResponseNewAuthOutStoreMsg {
-        _request_id: task.clone(),
-        _code: response_status_code,
-    };
-
-    let json_string =
-        serde_json_wasm::to_string(&data).map_err(|err| StdError::generic_err(err.to_string()))?;
-
-    let result = base64::encode(json_string);
-
-    let callback_msg = GatewayMsg::Output {
-        // Sepolia network gateway contract Solidity source code
-        //   https://github.com/SecretSaturn/SecretPath/blob/main/TNLS-Gateways/public-gateway/src/Gateway.sol
-        // Sepolia network gateway contract deployed code (line 383, 914)
-        //   https://sepolia.etherscan.io/address/0x0B6c705db59f7f02832d66B97b03E9EB3c0b4AAB#code
-        // Secret network gateway contract Rust source code `PostExecutionInfo`
-        //   https://github.com/SecretSaturn/SecretPath/blob/main/TNLS-Gateways/solana-gateway/programs/solana-gateway/src/lib.rs#L737
-        outputs: PostExecutionMsg {
-            result,
-            task, // task is the requestId
-            input_hash,
-        },
-    }
-    .to_cosmos_msg(
-        config.gateway_hash,
-        config.gateway_address.to_string(),
-        None,
-    )?;
-
-    Ok(Response::new()
-        .add_message(callback_msg)
-        .add_attribute("status", "create_new_auth_out"))
-}
-
-fn create_payment_reference(
-    deps: DepsMut,
-    _env: Env,
-    input_values: String,
-    task: Task,
-    input_hash: Binary,
-) -> StdResult<Response> {
-    let config = CONFIG.load(deps.storage)?;
-
-    let input: LinkPaymentRefStoreMsg = serde_json_wasm::from_str(&input_values)
-        .map_err(|err| StdError::generic_err(err.to_string()))?;
-
-    let viewing_key_index = input.secret_user.as_str(); // convert u8 to String
-
-    if viewing_key_index.chars().count() == 0 {
-        return Err(StdError::generic_err("Secret must not be an empty string"));
-    }
-
-    // https://docs.scrt.network/secret-network-documentation/development/development-concepts/permissioned-viewing/viewing-keys#viewing-keys-implementation
-    let gateway_account = config.gateway_address.to_owned();
-    let mut index_concat: String = gateway_account.to_string();
-    let suffix: &str = viewing_key_index;
-    index_concat.push_str(suffix);
-
-    let binding = "entropy".to_string();
-    let entropy: &str = binding.as_str();
-    let result = ViewingKey::check(deps.storage, &index_concat, entropy);
-    assert_ne!(result, Err(StdError::generic_err("unauthorized")));
-
-    let viewing_key = VIEWING_KEY
-        .get(deps.storage, &index_concat)
-        .ok_or_else(|| StdError::generic_err("Value for this VIEWING_KEY key not found"))?;
-
-    if viewing_key != index_concat {
-        return Err(StdError::generic_err("Viewing Key incorrect or not found"));
-    }
-
-    let payment_ref = input.payment_ref.as_str(); // convert Uint256 to String
-
-    if payment_ref.chars().count() == 0 {
-        return Err(StdError::generic_err("Payment reference must not be an empty string"));
-    }
-
-    // TODO: Check stored correctly but move to tests
-    let value_payment_reference_to_balances_map: Option<Vec<PaymentReferenceBalance>> = Some(VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP
-        .get(deps.storage, &index_concat)
-        .ok_or_else(|| StdError::generic_err("Value for this VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP key not found"))?);
-
-    // TODO: if payment_ref already exists in VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP value then early exit here
-
-    let new_balance: Coin = coin(0u128, String::new());
-    let new_payment_ref = payment_ref;
-    let new_payment_reference_balance = PaymentReferenceBalance {
-        payment_reference: new_payment_ref.to_string(),
-        balance: new_balance,
-    };
-
-    let mut value_payment_reference_to_balances: Vec<PaymentReferenceBalance> = match value_payment_reference_to_balances_map {
-        Some(payment_reference_to_balances) => payment_reference_to_balances, // If there are existing
-        None => Vec::new(),   // If none are found, start with an empty vector
-    };
-
-    // Add the new to vector
-    value_payment_reference_to_balances.push(new_payment_reference_balance.clone());
-
-    // Save updated back to storage
-    VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP
-        .insert(deps.storage, &viewing_key, &value_payment_reference_to_balances)?;
-
-    let response_status_code: ResponseStatusCode = 0u16;
-
-    let data = ResponseLinkPaymentRefStoreMsg {
-        _request_id: task.clone(),
-        _code: response_status_code,
-        _reference: new_payment_ref.to_string(),
-    };
-
-    let json_string =
-        serde_json_wasm::to_string(&data).map_err(|err| StdError::generic_err(err.to_string()))?;
-
-    let result = base64::encode(json_string);
-
-    let callback_msg = GatewayMsg::Output {
-        outputs: PostExecutionMsg {
-            result,
-            task,
-            input_hash,
-        },
-    }
-    .to_cosmos_msg(
-        config.gateway_hash,
-        config.gateway_address.to_string(),
-        None,
-    )?;
-
-    Ok(Response::new()
-        .add_message(callback_msg)
-        .add_attribute("status", "create_payment_reference"))
-}
-
-fn create_pay(
-    deps: DepsMut,
-    _env: Env,
-    input_values: String,
-    task: Task,
-    input_hash: Binary,
-) -> StdResult<Response> {
-    let config = CONFIG.load(deps.storage)?;
-
-    let input: PayStoreMsg = serde_json_wasm::from_str(&input_values)
-        .map_err(|err| StdError::generic_err(err.to_string()))?;
-
-    let viewing_key_index = input.secret_user.as_str(); // convert u8 to String
-    let payment_ref = input.payment_ref.as_str(); // convert Uint256 to String
-    // TODO: handle error if issue with amount or denomination received
-    let amount: Uint128 = input.amount.into(); // Uint128
-    let denomination = input.denomination.as_str();
-
-    if viewing_key_index.chars().count() == 0 {
-        return Err(StdError::generic_err("Secret must not be an empty string"));
-    }
-    if payment_ref.chars().count() == 0 {
-        return Err(StdError::generic_err("Payment reference must not be an empty string"));
-    }
-    if amount == <u128 as Into<Uint128>>::into(0u128) {
-        return Err(StdError::generic_err("Payment amount must be greater than 0"));
-    }
-    if denomination.chars().count() == 0 {
-        return Err(StdError::generic_err("Payment denomination must not be an empty string"));
-    }
-
-    // https://docs.scrt.network/secret-network-documentation/development/development-concepts/permissioned-viewing/viewing-keys#viewing-keys-implementation
-    let gateway_account = config.gateway_address.to_owned();
-    let mut index_concat: String = gateway_account.to_string();
-    let suffix: &str = viewing_key_index;
-    index_concat.push_str(suffix);
-
-    let binding = "entropy".to_string();
-    let entropy: &str = binding.as_str();
-    let result = ViewingKey::check(deps.storage, &index_concat, entropy);
-    assert_ne!(result, Err(StdError::generic_err("unauthorized")));
-
-    let viewing_key = VIEWING_KEY
-        .get(deps.storage, &index_concat)
-        .ok_or_else(|| StdError::generic_err("Value for this VIEWING_KEY key not found"))?;
-
-    if viewing_key != index_concat {
-        return Err(StdError::generic_err("Viewing Key incorrect or not found"));
-    }
-
-    // Attempt to retrieve existing
-    let value_payment_reference_to_balances_map: Option<Vec<PaymentReferenceBalance>> = Some(VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP
-        .get(deps.storage, &index_concat)
-        .ok_or_else(|| StdError::generic_err("Value for this VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP key not found"))?);
-
-    let mut value_payment_reference_to_balances: Vec<PaymentReferenceBalance> = match value_payment_reference_to_balances_map {
-        Some(payment_reference_to_balances) => payment_reference_to_balances, // If there are existing
-        None => return Err(StdError::generic_err("No payment references found")), // If none are found, early return
-    };
-
-    // Check if matching `payment_ref` is in the vector since only pay if it exists
-    let index: Option<usize> = Some(value_payment_reference_to_balances.iter().position(|r| r.payment_reference == payment_ref).unwrap());
-
-    let index_value_payment_reference_to_balances = match index {
-        Some(val) => {
-            println!("Found matching payment reference at index: {:#?}", val);
-            val
-        },
-        None => return Err(StdError::generic_err("No payment references found")),
-    };
-
-    // Add pay amount to existing balance associated with the payment reference that was found
-    let new_balance_amount: Uint128 = value_payment_reference_to_balances[index_value_payment_reference_to_balances].balance.amount.saturating_add(amount);
-    let new_balance: Coin = coin(<Uint128 as Into<u128>>::into(new_balance_amount), denomination);
-
-
-    let new_payment_reference_balance = PaymentReferenceBalance {
-        payment_reference: payment_ref.to_string(),
-        balance: new_balance,
-    };
-
-    // Update the index in the vector with the matching payment reference
-    value_payment_reference_to_balances[index_value_payment_reference_to_balances] = new_payment_reference_balance;
-
-    // Save updated back to storage
-    VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP
-        .insert(deps.storage, &viewing_key, &value_payment_reference_to_balances)?;
-
-    let receipt: PaymentReceipt;
-
-    // FIXME: sign receipt using Secret contract's private key, currently just hardcoded.
-    // But how to get the Secret contract's public and private key?
-    let signature: Binary = "0x".as_bytes().into();
-
-    let user_pubkey: Uint256;
-    if let Some(ref _user_pubkey) = input.user_pubkey {
-        user_pubkey = *_user_pubkey;
-
-        // TODO: if user_pubkey has been provided then return encrypted receipt and signature with the user_pubkey
-        // TODO: still need to encrypt below with user_pubkey
-        receipt = PaymentReceipt {
-            payment_reference: payment_ref.to_string(),
-            // TODO: convert Uint256 to Uint128
-            // Note: denomination of `Coin` type for the Receipt, since that is handled by the Solidity contract
-            amount: new_balance_amount.into(),
-            // TODO: serialise denomination
-            denomination: denomination.to_string(),
-            sig: signature,
-        };
-    } else {
-        // return receipt and signature unencrypted
-        receipt = PaymentReceipt {
-            payment_reference: payment_ref.to_string(),
-            // TODO: convert Uint256 to Uint128
-            // Note: denomination of `Coin` type for the Receipt, since that is handled by the Solidity contract
-            amount: new_balance_amount.into(),
-            // TODO: serialise denomination
-            denomination: denomination.to_string(),
-            sig: signature,
-        };
-    }
-
-    let response_status_code: ResponseStatusCode = 0u16;
-
-    let data = ResponsePayStoreMsg {
-        _request_id: task.clone(),
-        _code: response_status_code,
-        _receipt: receipt,
-    };
-
-    let json_string =
-        serde_json_wasm::to_string(&data).map_err(|err| StdError::generic_err(err.to_string()))?;
-
-    let result = base64::encode(json_string);
-
-    let callback_msg = GatewayMsg::Output {
-        outputs: PostExecutionMsg {
-            result,
-            task,
-            input_hash,
-        },
-    }
-    .to_cosmos_msg(
-        config.gateway_hash,
-        config.gateway_address.to_string(),
-        None,
-    )?;
-
-    Ok(Response::new()
-        .add_message(callback_msg)
-        .add_attribute("status", "create_pay"))
-}
-
-fn create_withdraw_to(
-    deps: DepsMut,
-    _env: Env,
-    input_values: String,
-    task: Task,
-    input_hash: Binary,
-) -> StdResult<Response> {
-    let config = CONFIG.load(deps.storage)?;
-
-    let input: WithdrawToStoreMsg = serde_json_wasm::from_str(&input_values)
-        .map_err(|err| StdError::generic_err(err.to_string()))?;
-
-    let viewing_key_index = input.secret_user.as_str(); // convert u8 to String
-
-    // Do not include receiving any payment reference since want to ignore it
-
-    // TODO: handle error if issue with amount or denomination received
-    let amount: Uint128 = input.amount.into(); // Uint128
-    let denomination = input.denomination.as_str();
-    let withdrawal_address: [u8; 20] = input.withdrawal_address.into(); // or `Addr`
-
-    if viewing_key_index.chars().count() == 0 {
-        return Err(StdError::generic_err("Secret must not be an empty string"));
-    }
-    // Do not validate payment reference since want to ignore it
-    if amount == <u128 as Into<Uint128>>::into(0u128) {
-        return Err(StdError::generic_err("Payment amount must be greater than 0"));
-    }
-    if denomination.chars().count() == 0 {
-        return Err(StdError::generic_err("Payment denomination must not be an empty string"));
-    }
-    // TODO: validate withdrawal address input. check if could be `Addr` type
-
-    // https://docs.scrt.network/secret-network-documentation/development/development-concepts/permissioned-viewing/viewing-keys#viewing-keys-implementation
-    let gateway_account = config.gateway_address.to_owned();
-    let mut index_concat: String = gateway_account.to_string();
-    let suffix: &str = viewing_key_index;
-    index_concat.push_str(suffix);
-
-    let binding = "entropy".to_string();
-    let entropy: &str = binding.as_str();
-    let result = ViewingKey::check(deps.storage, &index_concat, entropy);
-    assert_ne!(result, Err(StdError::generic_err("unauthorized")));
-
-    let value_viewing_key = VIEWING_KEY
-        .get(deps.storage, &index_concat)
-        .ok_or_else(|| StdError::generic_err("Value for this VIEWING_KEY key not found"))?;
-
-    if value_viewing_key != index_concat {
-        return Err(StdError::generic_err("Viewing Key incorrect or not found"));
-    }
-
-    // Attempt to retrieve existing
-    let value_payment_reference_to_balances_map: Option<Vec<PaymentReferenceBalance>> = Some(VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP
-        .get(deps.storage, &index_concat)
-        .ok_or_else(|| StdError::generic_err("Value for this VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP key not found"))?);
-
-    let value_payment_reference_to_balances: Vec<PaymentReferenceBalance> = match value_payment_reference_to_balances_map {
-        Some(payment_reference_to_balances) => payment_reference_to_balances, // If there are existing
-        None => return Err(StdError::generic_err("No payment references found")), // If none are found, early return
-    };
-
-    // Do not only withdraw associated with a specific payment reference at an index in the storage vector since want to ignore it
-    // Do not need to check that the `payment_ref` provided exists in storage since ignore it
-    // Do not need to check using the `payment_ref` that we want to withdraw using:
-    // the `amount` provided ensuring it is less than or equal to the amount stored associated with the payment reference
-    // and that the `denomination` matches the provided denomination that we want to withdraw
-
-    // Do not store withdrawal address in state
-    // Do not transfer anything on Secret Network
-    // Only authorise the withdrawal
-
-    let mut balance_all_payment_refs: Uint128 = 0u128.into();
-    for element in value_payment_reference_to_balances.into_iter() {
-        if element.balance.denom == denomination {
-            balance_all_payment_refs += element.balance.amount
-        }
-    }
-
-    if amount > balance_all_payment_refs {
-        return Err(StdError::generic_err("Withdrawal amount must be less than or equal to total balance of all payment references"));
-    }
-
-    let response_status_code: ResponseStatusCode = 0u16;
-
-    let data = ResponseWithdrawToStoreMsg {
-        _request_id: task.clone(),
-        _code: response_status_code,
-        _amount: amount,
-        _withdrawal_address: withdrawal_address,
-    };
-
-    let json_string =
-        serde_json_wasm::to_string(&data).map_err(|err| StdError::generic_err(err.to_string()))?;
-
-    let result = base64::encode(json_string);
-
-    let callback_msg = GatewayMsg::Output {
-        outputs: PostExecutionMsg {
-            result,
-            task,
-            input_hash,
-        },
-    }
-    .to_cosmos_msg(
-        config.gateway_hash,
-        config.gateway_address.to_string(),
-        None,
-    )?;
-
-    Ok(Response::new()
-        .add_message(callback_msg)
-        .add_attribute("status", "DO_THE_WITHDRAWAL"))
-}
-
-#[entry_point]
-pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
-    let response = match msg {
-        QueryMsg::RetrievePubkey {} => to_binary(&retrieve_pubkey_query(deps)?),
-    };
-    pad_query_result(response, BLOCK_SIZE)
-}
-
-fn retrieve_pubkey_query(deps: Deps) -> StdResult<ResponseRetrievePubkeyMsg> {
-    let my_keys = MY_KEYS.load(deps.storage)?;
-    Ok(ResponseRetrievePubkeyMsg {
-        _key: my_keys.public_key,
-    })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use cosmwasm_std::testing::{message_info, mock_dependencies, mock_dependencies_with_balances, mock_env};
-    use cosmwasm_std::coins;
-    use cosmwasm_std::{from_binary, StdError};
-
-    #[test]
-    fn proper_initialization() {
-        let mut deps = mock_dependencies();
-        // Create some Addr instances for testing
-        let gateway = deps.api.addr_make("gateway");
-        // https://docs.rs/cosmwasm-std/latest/cosmwasm_std/testing/fn.message_info.html
-        let msg = InstantiateMsg {
-            gateway_address: gateway.to_string(),
-        };
-
-        let info = message_info(&gateway, &coins(1000, "earth"));
-        // we can just call .unwrap() to assert this was a success
-        let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
-
-        assert_eq!(0, res.messages.len());
-
-        // it worked, let's query the state
-        let res = query(deps.as_ref(), mock_env(), QueryMsg::RetrievePubkey {}).unwrap();
-        let res: ResponseRetrievePubkeyMsg = from_binary(&res).unwrap();
-        assert!(res._key);
-    }
-}
+// fn create_new_auth_out(
+//     deps: DepsMut,
+//     env: Env,
+//     info: MessageInfo,
+//     input_values: String,
+//     task: Task,
+//     input_hash: Binary,
+// ) -> StdResult<Response> {
+//     let config = CONFIG.load(deps.storage)?;
+
+//     let input: NewAuthOutStoreMsg = serde_json_wasm::from_str(&input_values)
+//         .map_err(|err| StdError::generic_err(err.to_string()))?;
+
+//     let viewing_key_index = input.secret_user.as_str(); // convert u8 to String
+
+//     if viewing_key_index.chars().count() == 0 {
+//         return Err(StdError::generic_err("Secret must not be an empty string"));
+//     }
+
+//     // https://docs.scrt.network/secret-network-documentation/development/development-concepts/permissioned-viewing/viewing-keys#viewing-keys-implementation
+//     let gateway_account = config.gateway_address.to_owned();
+//     let mut index_concat: String = gateway_account.to_string();
+//     let suffix: &str = viewing_key_index;
+//     // mutate in place https://stackoverflow.com/a/30154791/3208553
+//     index_concat.push_str(suffix);
+
+//     // https://docs.scrt.network/secret-network-documentation/development/development-concepts/permissioned-viewing/viewing-keys#viewing-keys-introduction
+//     // https://github.com/scrtlabs/examples/blob/master/secret-viewing-keys/secret-viewing-keys-contract/src/contract.rs
+//     let entropy: &[u8] = b"entropy";
+//     let viewing_key = ViewingKey::create(deps.storage, &info, &env, gateway_account.as_str(), entropy);
+
+//     // Viewing Key
+//     VIEWING_KEY
+//         // TODO - sender is always the gateway contract, or perhaps change this to `info.sender.as_bytes()`
+//         .add_suffix(config.gateway_address.as_bytes())
+//         .insert(deps.storage, &viewing_key_index.to_string(), &viewing_key)?;
+
+//     // Attempt to retrieve existing
+//     let value_payment_reference_to_balances_map: Option<Vec<PaymentReferenceBalance>> = Some(VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP
+//         .get(deps.storage, &index_concat)
+//         .ok_or_else(|| StdError::generic_err("Value for this VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP key not found"))?);
+
+//     // TODO: need to setup viewing key for the mapping, but not necessary to store this example
+//     let init_balance: Coin = coin(0u128, String::new());
+//     let init_payment_ref = String::new();
+//     let init_payment_reference_balance = PaymentReferenceBalance {
+//         payment_reference: init_payment_ref,
+//         balance: init_balance,
+//     };
+
+//     let mut value_payment_reference_to_balances: Vec<PaymentReferenceBalance> = match value_payment_reference_to_balances_map {
+//         Some(payment_reference_to_balances) => payment_reference_to_balances, // If there are existing
+//         None => Vec::new(),   // If none are found, start with an empty vector
+//     };
+
+//     // Add the new to vector
+//     value_payment_reference_to_balances.push(init_payment_reference_balance.clone());
+
+//     // Save updated back to storage
+//     VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP
+//         .insert(deps.storage, &viewing_key, &value_payment_reference_to_balances)?;
+
+//     let response_status_code: ResponseStatusCode = 0u16;
+
+//     let data = ResponseNewAuthOutStoreMsg {
+//         _request_id: task.clone(),
+//         _code: response_status_code,
+//     };
+
+//     let json_string =
+//         serde_json_wasm::to_string(&data).map_err(|err| StdError::generic_err(err.to_string()))?;
+
+//     let result = base64::encode(json_string);
+
+//     let callback_msg = GatewayMsg::Output {
+//         // Sepolia network gateway contract Solidity source code
+//         //   https://github.com/SecretSaturn/SecretPath/blob/main/TNLS-Gateways/public-gateway/src/Gateway.sol
+//         // Sepolia network gateway contract deployed code (line 383, 914)
+//         //   https://sepolia.etherscan.io/address/0x0B6c705db59f7f02832d66B97b03E9EB3c0b4AAB#code
+//         // Secret network gateway contract Rust source code `PostExecutionInfo`
+//         //   https://github.com/SecretSaturn/SecretPath/blob/main/TNLS-Gateways/solana-gateway/programs/solana-gateway/src/lib.rs#L737
+//         outputs: PostExecutionMsg {
+//             result,
+//             task, // task is the requestId
+//             input_hash,
+//         },
+//     }
+//     .to_cosmos_msg(
+//         config.gateway_hash,
+//         config.gateway_address.to_string(),
+//         None,
+//     )?;
+
+//     Ok(Response::new()
+//         .add_message(callback_msg)
+//         .add_attribute("status", "create_new_auth_out"))
+// }
+
+// fn create_payment_reference(
+//     deps: DepsMut,
+//     _env: Env,
+//     input_values: String,
+//     task: Task,
+//     input_hash: Binary,
+// ) -> StdResult<Response> {
+//     let config = CONFIG.load(deps.storage)?;
+
+//     let input: LinkPaymentRefStoreMsg = serde_json_wasm::from_str(&input_values)
+//         .map_err(|err| StdError::generic_err(err.to_string()))?;
+
+//     let viewing_key_index = input.secret_user.as_str(); // convert u8 to String
+
+//     if viewing_key_index.chars().count() == 0 {
+//         return Err(StdError::generic_err("Secret must not be an empty string"));
+//     }
+
+//     // https://docs.scrt.network/secret-network-documentation/development/development-concepts/permissioned-viewing/viewing-keys#viewing-keys-implementation
+//     let gateway_account = config.gateway_address.to_owned();
+//     let mut index_concat: String = gateway_account.to_string();
+//     let suffix: &str = viewing_key_index;
+//     index_concat.push_str(suffix);
+
+//     let binding = "entropy".to_string();
+//     let entropy: &str = binding.as_str();
+//     let result = ViewingKey::check(deps.storage, &index_concat, entropy);
+//     assert_ne!(result, Err(StdError::generic_err("unauthorized")));
+
+//     let viewing_key = VIEWING_KEY
+//         .get(deps.storage, &index_concat)
+//         .ok_or_else(|| StdError::generic_err("Value for this VIEWING_KEY key not found"))?;
+
+//     if viewing_key != index_concat {
+//         return Err(StdError::generic_err("Viewing Key incorrect or not found"));
+//     }
+
+//     let payment_ref = input.payment_ref.as_str(); // convert Uint256 to String
+
+//     if payment_ref.chars().count() == 0 {
+//         return Err(StdError::generic_err("Payment reference must not be an empty string"));
+//     }
+
+//     // TODO: Check stored correctly but move to tests
+//     let value_payment_reference_to_balances_map: Option<Vec<PaymentReferenceBalance>> = Some(VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP
+//         .get(deps.storage, &index_concat)
+//         .ok_or_else(|| StdError::generic_err("Value for this VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP key not found"))?);
+
+//     // TODO: if payment_ref already exists in VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP value then early exit here
+
+//     let new_balance: Coin = coin(0u128, String::new());
+//     let new_payment_ref = payment_ref;
+//     let new_payment_reference_balance = PaymentReferenceBalance {
+//         payment_reference: new_payment_ref.to_string(),
+//         balance: new_balance,
+//     };
+
+//     let mut value_payment_reference_to_balances: Vec<PaymentReferenceBalance> = match value_payment_reference_to_balances_map {
+//         Some(payment_reference_to_balances) => payment_reference_to_balances, // If there are existing
+//         None => Vec::new(),   // If none are found, start with an empty vector
+//     };
+
+//     // Add the new to vector
+//     value_payment_reference_to_balances.push(new_payment_reference_balance.clone());
+
+//     // Save updated back to storage
+//     VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP
+//         .insert(deps.storage, &viewing_key, &value_payment_reference_to_balances)?;
+
+//     let response_status_code: ResponseStatusCode = 0u16;
+
+//     let data = ResponseLinkPaymentRefStoreMsg {
+//         _request_id: task.clone(),
+//         _code: response_status_code,
+//         _reference: new_payment_ref.to_string(),
+//     };
+
+//     let json_string =
+//         serde_json_wasm::to_string(&data).map_err(|err| StdError::generic_err(err.to_string()))?;
+
+//     let result = base64::encode(json_string);
+
+//     let callback_msg = GatewayMsg::Output {
+//         outputs: PostExecutionMsg {
+//             result,
+//             task,
+//             input_hash,
+//         },
+//     }
+//     .to_cosmos_msg(
+//         config.gateway_hash,
+//         config.gateway_address.to_string(),
+//         None,
+//     )?;
+
+//     Ok(Response::new()
+//         .add_message(callback_msg)
+//         .add_attribute("status", "create_payment_reference"))
+// }
+
+// fn create_pay(
+//     deps: DepsMut,
+//     _env: Env,
+//     input_values: String,
+//     task: Task,
+//     input_hash: Binary,
+// ) -> StdResult<Response> {
+//     let config = CONFIG.load(deps.storage)?;
+
+//     let input: PayStoreMsg = serde_json_wasm::from_str(&input_values)
+//         .map_err(|err| StdError::generic_err(err.to_string()))?;
+
+//     let viewing_key_index = input.secret_user.as_str(); // convert u8 to String
+//     let payment_ref = input.payment_ref.as_str(); // convert Uint256 to String
+//     // TODO: handle error if issue with amount or denomination received
+//     let amount: Uint128 = input.amount.into(); // Uint128
+//     let denomination = input.denomination.as_str();
+
+//     if viewing_key_index.chars().count() == 0 {
+//         return Err(StdError::generic_err("Secret must not be an empty string"));
+//     }
+//     if payment_ref.chars().count() == 0 {
+//         return Err(StdError::generic_err("Payment reference must not be an empty string"));
+//     }
+//     if amount == <u128 as Into<Uint128>>::into(0u128) {
+//         return Err(StdError::generic_err("Payment amount must be greater than 0"));
+//     }
+//     if denomination.chars().count() == 0 {
+//         return Err(StdError::generic_err("Payment denomination must not be an empty string"));
+//     }
+
+//     // https://docs.scrt.network/secret-network-documentation/development/development-concepts/permissioned-viewing/viewing-keys#viewing-keys-implementation
+//     let gateway_account = config.gateway_address.to_owned();
+//     let mut index_concat: String = gateway_account.to_string();
+//     let suffix: &str = viewing_key_index;
+//     index_concat.push_str(suffix);
+
+//     let binding = "entropy".to_string();
+//     let entropy: &str = binding.as_str();
+//     let result = ViewingKey::check(deps.storage, &index_concat, entropy);
+//     assert_ne!(result, Err(StdError::generic_err("unauthorized")));
+
+//     let viewing_key = VIEWING_KEY
+//         .get(deps.storage, &index_concat)
+//         .ok_or_else(|| StdError::generic_err("Value for this VIEWING_KEY key not found"))?;
+
+//     if viewing_key != index_concat {
+//         return Err(StdError::generic_err("Viewing Key incorrect or not found"));
+//     }
+
+//     // Attempt to retrieve existing
+//     let value_payment_reference_to_balances_map: Option<Vec<PaymentReferenceBalance>> = Some(VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP
+//         .get(deps.storage, &index_concat)
+//         .ok_or_else(|| StdError::generic_err("Value for this VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP key not found"))?);
+
+//     let mut value_payment_reference_to_balances: Vec<PaymentReferenceBalance> = match value_payment_reference_to_balances_map {
+//         Some(payment_reference_to_balances) => payment_reference_to_balances, // If there are existing
+//         None => return Err(StdError::generic_err("No payment references found")), // If none are found, early return
+//     };
+
+//     // Check if matching `payment_ref` is in the vector since only pay if it exists
+//     let index: Option<usize> = Some(value_payment_reference_to_balances.iter().position(|r| r.payment_reference == payment_ref).unwrap());
+
+//     let index_value_payment_reference_to_balances = match index {
+//         Some(val) => {
+//             println!("Found matching payment reference at index: {:#?}", val);
+//             val
+//         },
+//         None => return Err(StdError::generic_err("No payment references found")),
+//     };
+
+//     // Add pay amount to existing balance associated with the payment reference that was found
+//     let new_balance_amount: Uint128 = value_payment_reference_to_balances[index_value_payment_reference_to_balances].balance.amount.saturating_add(amount);
+//     let new_balance: Coin = coin(<Uint128 as Into<u128>>::into(new_balance_amount), denomination);
+
+
+//     let new_payment_reference_balance = PaymentReferenceBalance {
+//         payment_reference: payment_ref.to_string(),
+//         balance: new_balance,
+//     };
+
+//     // Update the index in the vector with the matching payment reference
+//     value_payment_reference_to_balances[index_value_payment_reference_to_balances] = new_payment_reference_balance;
+
+//     // Save updated back to storage
+//     VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP
+//         .insert(deps.storage, &viewing_key, &value_payment_reference_to_balances)?;
+
+//     let receipt: PaymentReceipt;
+
+//     // FIXME: sign receipt using Secret contract's private key, currently just hardcoded.
+//     // But how to get the Secret contract's public and private key?
+//     let signature: Binary = "0x".as_bytes().into();
+
+//     let user_pubkey: Uint256;
+//     if let Some(ref _user_pubkey) = input.user_pubkey {
+//         user_pubkey = *_user_pubkey;
+
+//         // TODO: if user_pubkey has been provided then return encrypted receipt and signature with the user_pubkey
+//         // TODO: still need to encrypt below with user_pubkey
+//         receipt = PaymentReceipt {
+//             payment_reference: payment_ref.to_string(),
+//             // TODO: convert Uint256 to Uint128
+//             // Note: denomination of `Coin` type for the Receipt, since that is handled by the Solidity contract
+//             amount: new_balance_amount.into(),
+//             // TODO: serialise denomination
+//             denomination: denomination.to_string(),
+//             sig: signature,
+//         };
+//     } else {
+//         // return receipt and signature unencrypted
+//         receipt = PaymentReceipt {
+//             payment_reference: payment_ref.to_string(),
+//             // TODO: convert Uint256 to Uint128
+//             // Note: denomination of `Coin` type for the Receipt, since that is handled by the Solidity contract
+//             amount: new_balance_amount.into(),
+//             // TODO: serialise denomination
+//             denomination: denomination.to_string(),
+//             sig: signature,
+//         };
+//     }
+
+//     let response_status_code: ResponseStatusCode = 0u16;
+
+//     let data = ResponsePayStoreMsg {
+//         _request_id: task.clone(),
+//         _code: response_status_code,
+//         _receipt: receipt,
+//     };
+
+//     let json_string =
+//         serde_json_wasm::to_string(&data).map_err(|err| StdError::generic_err(err.to_string()))?;
+
+//     let result = base64::encode(json_string);
+
+//     let callback_msg = GatewayMsg::Output {
+//         outputs: PostExecutionMsg {
+//             result,
+//             task,
+//             input_hash,
+//         },
+//     }
+//     .to_cosmos_msg(
+//         config.gateway_hash,
+//         config.gateway_address.to_string(),
+//         None,
+//     )?;
+
+//     Ok(Response::new()
+//         .add_message(callback_msg)
+//         .add_attribute("status", "create_pay"))
+// }
+
+// fn create_withdraw_to(
+//     deps: DepsMut,
+//     _env: Env,
+//     input_values: String,
+//     task: Task,
+//     input_hash: Binary,
+// ) -> StdResult<Response> {
+//     let config = CONFIG.load(deps.storage)?;
+
+//     let input: WithdrawToStoreMsg = serde_json_wasm::from_str(&input_values)
+//         .map_err(|err| StdError::generic_err(err.to_string()))?;
+
+//     let viewing_key_index = input.secret_user.as_str(); // convert u8 to String
+
+//     // Do not include receiving any payment reference since want to ignore it
+
+//     // TODO: handle error if issue with amount or denomination received
+//     let amount: Uint128 = input.amount.into(); // Uint128
+//     let denomination = input.denomination.as_str();
+//     let withdrawal_address: [u8; 20] = input.withdrawal_address.into(); // or `Addr`
+
+//     if viewing_key_index.chars().count() == 0 {
+//         return Err(StdError::generic_err("Secret must not be an empty string"));
+//     }
+//     // Do not validate payment reference since want to ignore it
+//     if amount == <u128 as Into<Uint128>>::into(0u128) {
+//         return Err(StdError::generic_err("Payment amount must be greater than 0"));
+//     }
+//     if denomination.chars().count() == 0 {
+//         return Err(StdError::generic_err("Payment denomination must not be an empty string"));
+//     }
+//     // TODO: validate withdrawal address input. check if could be `Addr` type
+
+//     // https://docs.scrt.network/secret-network-documentation/development/development-concepts/permissioned-viewing/viewing-keys#viewing-keys-implementation
+//     let gateway_account = config.gateway_address.to_owned();
+//     let mut index_concat: String = gateway_account.to_string();
+//     let suffix: &str = viewing_key_index;
+//     index_concat.push_str(suffix);
+
+//     let binding = "entropy".to_string();
+//     let entropy: &str = binding.as_str();
+//     let result = ViewingKey::check(deps.storage, &index_concat, entropy);
+//     assert_ne!(result, Err(StdError::generic_err("unauthorized")));
+
+//     let value_viewing_key = VIEWING_KEY
+//         .get(deps.storage, &index_concat)
+//         .ok_or_else(|| StdError::generic_err("Value for this VIEWING_KEY key not found"))?;
+
+//     if value_viewing_key != index_concat {
+//         return Err(StdError::generic_err("Viewing Key incorrect or not found"));
+//     }
+
+//     // Attempt to retrieve existing
+//     let value_payment_reference_to_balances_map: Option<Vec<PaymentReferenceBalance>> = Some(VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP
+//         .get(deps.storage, &index_concat)
+//         .ok_or_else(|| StdError::generic_err("Value for this VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP key not found"))?);
+
+//     let value_payment_reference_to_balances: Vec<PaymentReferenceBalance> = match value_payment_reference_to_balances_map {
+//         Some(payment_reference_to_balances) => payment_reference_to_balances, // If there are existing
+//         None => return Err(StdError::generic_err("No payment references found")), // If none are found, early return
+//     };
+
+//     // Do not only withdraw associated with a specific payment reference at an index in the storage vector since want to ignore it
+//     // Do not need to check that the `payment_ref` provided exists in storage since ignore it
+//     // Do not need to check using the `payment_ref` that we want to withdraw using:
+//     // the `amount` provided ensuring it is less than or equal to the amount stored associated with the payment reference
+//     // and that the `denomination` matches the provided denomination that we want to withdraw
+
+//     // Do not store withdrawal address in state
+//     // Do not transfer anything on Secret Network
+//     // Only authorise the withdrawal
+
+//     let mut balance_all_payment_refs: Uint128 = 0u128.into();
+//     for element in value_payment_reference_to_balances.into_iter() {
+//         if element.balance.denom == denomination {
+//             balance_all_payment_refs += element.balance.amount
+//         }
+//     }
+
+//     if amount > balance_all_payment_refs {
+//         return Err(StdError::generic_err("Withdrawal amount must be less than or equal to total balance of all payment references"));
+//     }
+
+//     let response_status_code: ResponseStatusCode = 0u16;
+
+//     let data = ResponseWithdrawToStoreMsg {
+//         _request_id: task.clone(),
+//         _code: response_status_code,
+//         _amount: amount,
+//         _withdrawal_address: withdrawal_address,
+//     };
+
+//     let json_string =
+//         serde_json_wasm::to_string(&data).map_err(|err| StdError::generic_err(err.to_string()))?;
+
+//     let result = base64::encode(json_string);
+
+//     let callback_msg = GatewayMsg::Output {
+//         outputs: PostExecutionMsg {
+//             result,
+//             task,
+//             input_hash,
+//         },
+//     }
+//     .to_cosmos_msg(
+//         config.gateway_hash,
+//         config.gateway_address.to_string(),
+//         None,
+//     )?;
+
+//     Ok(Response::new()
+//         .add_message(callback_msg)
+//         .add_attribute("status", "DO_THE_WITHDRAWAL"))
+// }
+
+// #[entry_point]
+// pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+//     let response = match msg {
+//         QueryMsg::RetrievePubkey {} => to_binary(&retrieve_pubkey_query(deps)?),
+//     };
+//     pad_query_result(response, BLOCK_SIZE)
+// }
+
+// fn retrieve_pubkey_query(deps: Deps) -> StdResult<ResponseRetrievePubkeyMsg> {
+//     let my_keys = MY_KEYS.load(deps.storage)?;
+//     Ok(ResponseRetrievePubkeyMsg {
+//         _key: my_keys.public_key,
+//     })
+// }
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use cosmwasm_std::testing::{message_info, mock_dependencies, mock_dependencies_with_balances, mock_env};
+//     use cosmwasm_std::coins;
+//     use cosmwasm_std::{from_binary, StdError};
+
+//     #[test]
+//     fn proper_initialization() {
+//         let mut deps = mock_dependencies();
+//         // Create some Addr instances for testing
+//         let gateway = deps.api.addr_make("gateway");
+//         // https://docs.rs/cosmwasm-std/latest/cosmwasm_std/testing/fn.message_info.html
+//         let msg = InstantiateMsg {
+//             gateway_address: gateway.to_string(),
+//         };
+
+//         let info = message_info(&gateway, &coins(1000, "earth"));
+//         // we can just call .unwrap() to assert this was a success
+//         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+//         assert_eq!(0, res.messages.len());
+
+//         // it worked, let's query the state
+//         let res = query(deps.as_ref(), mock_env(), QueryMsg::RetrievePubkey {}).unwrap();
+//         let res: ResponseRetrievePubkeyMsg = from_binary(&res).unwrap();
+//         assert!(res._key);
+//     }
+// }

--- a/packages/secret-contracts/nunya-contract/src/contract.rs
+++ b/packages/secret-contracts/nunya-contract/src/contract.rs
@@ -13,18 +13,20 @@ use crate::{
     // },
 };
 use cosmwasm_std::{
-    entry_point, to_binary, coin, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128, Uint256
+    entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult,
+    // coin, Coin,
+    // Uint128, Uint256
 };
-use secret_toolkit::viewing_key::{ViewingKey, ViewingKeyStore};
-use secret_toolkit::utils::{pad_handle_result, pad_query_result, HandleCallback};
-use tnls::{
-    msg::{PostExecutionMsg, PrivContractHandleMsg},
-    state::Task,
-};
+// use secret_toolkit::viewing_key::{ViewingKey, ViewingKeyStore};
+// use secret_toolkit::utils::{pad_handle_result, pad_query_result, HandleCallback};
+// use tnls::{
+//     msg::{PostExecutionMsg, PrivContractHandleMsg},
+//     state::Task,
+// };
 
-/// pad handle responses and log attributes to blocks of 256 bytes to prevent leaking info based on
-/// response size
-pub const BLOCK_SIZE: usize = 256;
+// /// pad handle responses and log attributes to blocks of 256 bytes to prevent leaking info based on
+// /// response size
+// pub const BLOCK_SIZE: usize = 256;
 
 #[entry_point]
 pub fn instantiate(
@@ -45,54 +47,54 @@ pub fn instantiate(
     Ok(Response::default())
 }
 
-#[entry_point]
-pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
-    let response = match msg {
-        ExecuteMsg::Input { message } => try_handle(deps, env, info, message),
-    };
-    pad_handle_result(response, BLOCK_SIZE)
-}
+// #[entry_point]
+// pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
+//     let response = match msg {
+//         ExecuteMsg::Input { message } => try_handle(deps, env, info, message),
+//     };
+//     pad_handle_result(response, BLOCK_SIZE)
+// }
 
-// acts like a gateway message handle filter
-fn try_handle(
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    msg: PrivContractHandleMsg,
-) -> StdResult<Response> {
-    // verify signature with stored gateway public key
-    // let config = CONFIG.load(deps.storage)?;
+// // acts like a gateway message handle filter
+// fn try_handle(
+//     deps: DepsMut,
+//     env: Env,
+//     info: MessageInfo,
+//     msg: PrivContractHandleMsg,
+// ) -> StdResult<Response> {
+//     // verify signature with stored gateway public key
+//     // let config = CONFIG.load(deps.storage)?;
 
-    // // Security
-    // //
-    // // reference: evm-kv-store-demo
-    // if info.sender != config.gateway_address {
-    //     return Err(StdError::generic_err(
-    //         "Only SecretPath Gateway can call this function",
-    //     ));
-    // }
+//     // // Security
+//     // //
+//     // // reference: evm-kv-store-demo
+//     // if info.sender != config.gateway_address {
+//     //     return Err(StdError::generic_err(
+//     //         "Only SecretPath Gateway can call this function",
+//     //     ));
+//     // }
 
-    // deps.api
-    //     .secp256k1_verify(
-    //         msg.input_hash.as_slice(),
-    //         msg.signature.as_slice(),
-    //         config.gateway_key.as_slice(),
-    //     )
-    //     .map_err(|err| StdError::generic_err(err.to_string()))?;
+//     // deps.api
+//     //     .secp256k1_verify(
+//     //         msg.input_hash.as_slice(),
+//     //         msg.signature.as_slice(),
+//     //         config.gateway_key.as_slice(),
+//     //     )
+//     //     .map_err(|err| StdError::generic_err(err.to_string()))?;
 
-    // determine which function to call based on the included handle
-    let handle = msg.handle.as_str();
-    match handle {
-        // "newSecretUser" => create_new_auth_out(deps, env, info, msg.input_values, msg.task, msg.input_hash),
-        // "createPaymentReference" => create_payment_reference(deps, env, msg.input_values, msg.task, msg.input_hash),
-        // // handle both `pay` and `payWithReceipt` Solidity function calls using the same `create_pay` Secret contract function
-        // "pay" => create_pay(deps, env, msg.input_values, msg.task, msg.input_hash),
-        // "payWithReceipt" => create_pay(deps, env, msg.input_values, msg.task, msg.input_hash),
-        // "withdrawTo" => create_withdraw_to(deps, env, msg.input_values, msg.task, msg.input_hash),
+//     // determine which function to call based on the included handle
+//     let handle = msg.handle.as_str();
+//     match handle {
+//         // "newSecretUser" => create_new_auth_out(deps, env, info, msg.input_values, msg.task, msg.input_hash),
+//         // "createPaymentReference" => create_payment_reference(deps, env, msg.input_values, msg.task, msg.input_hash),
+//         // // handle both `pay` and `payWithReceipt` Solidity function calls using the same `create_pay` Secret contract function
+//         // "pay" => create_pay(deps, env, msg.input_values, msg.task, msg.input_hash),
+//         // "payWithReceipt" => create_pay(deps, env, msg.input_values, msg.task, msg.input_hash),
+//         // "withdrawTo" => create_withdraw_to(deps, env, msg.input_values, msg.task, msg.input_hash),
 
-        _ => Err(StdError::generic_err("invalid handle".to_string())),
-    }
-}
+//         _ => Err(StdError::generic_err("invalid handle".to_string())),
+//     }
+// }
 
 // fn create_new_auth_out(
 //     deps: DepsMut,

--- a/packages/secret-contracts/nunya-contract/src/lib.rs
+++ b/packages/secret-contracts/nunya-contract/src/lib.rs
@@ -1,3 +1,3 @@
 pub mod contract;
 pub mod msg;
-pub mod state;
+// pub mod state;

--- a/packages/secret-contracts/nunya-contract/src/msg.rs
+++ b/packages/secret-contracts/nunya-contract/src/msg.rs
@@ -1,7 +1,10 @@
-use cosmwasm_std::{Addr, Binary, Uint128, Uint256};
-use secret_toolkit::utils::HandleCallback;
-use tnls::msg::{PostExecutionMsg, PrivContractHandleMsg};
-use tnls::state::{Task};
+// use cosmwasm_std::{Addr, Binary, Uint128, Uint256};
+// use secret_toolkit::utils::HandleCallback;
+use tnls::msg::{
+    // PostExecutionMsg,
+    PrivContractHandleMsg
+};
+// use tnls::state::{Task};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -14,15 +17,15 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
-    pub gateway_address: Addr,
-    pub gateway_hash: String,
-    pub gateway_key: Binary,
+    // pub gateway_address: Addr,
+    // pub gateway_hash: String,
+    // pub gateway_key: Binary,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    Input { message: PrivContractHandleMsg },
+    // Input { message: PrivContractHandleMsg },
 }
 
 // #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/secret-contracts/nunya-contract/src/msg.rs
+++ b/packages/secret-contracts/nunya-contract/src/msg.rs
@@ -1,9 +1,9 @@
 // use cosmwasm_std::{Addr, Binary, Uint128, Uint256};
 // use secret_toolkit::utils::HandleCallback;
-use tnls::msg::{
-    // PostExecutionMsg,
-    PrivContractHandleMsg
-};
+// use tnls::msg::{
+//     PostExecutionMsg,
+//     PrivContractHandleMsg
+// };
 // use tnls::state::{Task};
 
 use schemars::JsonSchema;

--- a/packages/secret-contracts/nunya-contract/src/msg.rs
+++ b/packages/secret-contracts/nunya-contract/src/msg.rs
@@ -6,11 +6,11 @@ use tnls::state::{Task};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    state::{
-        PaymentReceipt, ResponseStatusCode,
-    }
-};
+// use crate::{
+//     state::{
+//         PaymentReceipt, ResponseStatusCode,
+//     }
+// };
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
@@ -25,90 +25,90 @@ pub enum ExecuteMsg {
     Input { message: PrivContractHandleMsg },
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct NewAuthOutStoreMsg {
-    // TODO - is this key the variable of the parameter provided from Solidity contract to its new_secret_user function?
-    // secret_user or auth_out
-    pub secret_user: String,
-}
+// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+// pub struct NewAuthOutStoreMsg {
+//     // TODO - is this key the variable of the parameter provided from Solidity contract to its new_secret_user function?
+//     // secret_user or auth_out
+//     pub secret_user: String,
+// }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct LinkPaymentRefStoreMsg {
-    pub secret_user: String,
-    pub payment_ref: String,
-}
+// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+// pub struct LinkPaymentRefStoreMsg {
+//     pub secret_user: String,
+//     pub payment_ref: String,
+// }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct PayStoreMsg {
-    pub secret_user: String,
-    pub payment_ref: String,
-    pub amount: Uint128,
-    pub denomination: String,
-    pub user_pubkey: Option<Uint256>, // encrypted with receipt
-}
+// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+// pub struct PayStoreMsg {
+//     pub secret_user: String,
+//     pub payment_ref: String,
+//     pub amount: Uint128,
+//     pub denomination: String,
+//     pub user_pubkey: Option<Uint256>, // encrypted with receipt
+// }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct WithdrawToStoreMsg {
-    pub secret_user: String,
-    pub amount: Uint128,
-    pub denomination: String,
-    pub withdrawal_address: [u8; 20],
-}
+// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+// pub struct WithdrawToStoreMsg {
+//     pub secret_user: String,
+//     pub amount: Uint128,
+//     pub denomination: String,
+//     pub withdrawal_address: [u8; 20],
+// }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct ResponseNewAuthOutStoreMsg {
-    pub _request_id: Task,
-    pub _code: ResponseStatusCode,
-}
+// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+// pub struct ResponseNewAuthOutStoreMsg {
+//     pub _request_id: Task,
+//     pub _code: ResponseStatusCode,
+// }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct ResponseLinkPaymentRefStoreMsg {
-    pub _request_id: Task,
-    pub _code: ResponseStatusCode,
-    pub _reference: String,
-}
+// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+// pub struct ResponseLinkPaymentRefStoreMsg {
+//     pub _request_id: Task,
+//     pub _code: ResponseStatusCode,
+//     pub _reference: String,
+// }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct ResponsePayStoreMsg {
-    pub _request_id: Task,
-    pub _code: ResponseStatusCode,
-    pub _receipt: PaymentReceipt,
-}
+// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+// pub struct ResponsePayStoreMsg {
+//     pub _request_id: Task,
+//     pub _code: ResponseStatusCode,
+//     pub _receipt: PaymentReceipt,
+// }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct ResponseWithdrawToStoreMsg {
-    pub _request_id: Task,
-    pub _code: ResponseStatusCode,
-    pub _amount: Uint128,
-    // TODO: should this be of type `Addr`? does it support EVM addresses?
-    pub _withdrawal_address: [u8; 20],
-}
+// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+// pub struct ResponseWithdrawToStoreMsg {
+//     pub _request_id: Task,
+//     pub _code: ResponseStatusCode,
+//     pub _amount: Uint128,
+//     // TODO: should this be of type `Addr`? does it support EVM addresses?
+//     pub _withdrawal_address: [u8; 20],
+// }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum QueryMsg {
-    RetrievePubkey {},
-}
+// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+// #[serde(rename_all = "snake_case")]
+// pub enum QueryMsg {
+//     RetrievePubkey {},
+// }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct ResponseRetrievePubkeyMsg {
-    // TODO: can only access `_requestId` if function called from `try_handle` and callback, but not from queries
-    // pub _requestId: Uint256,
-    pub _key: Vec<u8>,
-}
+// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+// pub struct ResponseRetrievePubkeyMsg {
+//     // TODO: can only access `_requestId` if function called from `try_handle` and callback, but not from queries
+//     // pub _requestId: Uint256,
+//     pub _key: Vec<u8>,
+// }
 
-// TODO: this may not be necessary as not used
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-pub struct QueryResponse {
-    pub message: String,
-}
+// // TODO: this may not be necessary as not used
+// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+// pub struct QueryResponse {
+//     pub message: String,
+// }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum GatewayMsg {
-    Output { outputs: PostExecutionMsg },
-}
+// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+// #[serde(rename_all = "snake_case")]
+// pub enum GatewayMsg {
+//     Output { outputs: PostExecutionMsg },
+// }
 
-impl HandleCallback for GatewayMsg {
-    const BLOCK_SIZE: usize = 256;
-}
+// impl HandleCallback for GatewayMsg {
+//     const BLOCK_SIZE: usize = 256;
+// }

--- a/packages/secret-contracts/nunya-contract/src/state.rs
+++ b/packages/secret-contracts/nunya-contract/src/state.rs
@@ -4,17 +4,17 @@ use secret_toolkit::storage::{Item, Keymap};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-pub static MY_KEYS: Item<MyKeys> = Item::new(b"my_keys");
+// pub static MY_KEYS: Item<MyKeys> = Item::new(b"my_keys");
 pub static CONFIG: Item<State> = Item::new(b"config");
-pub static VIEWING_KEY: Keymap<Index, VK> = Keymap::new(b"VIEWING_KEY");
-pub static VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP: Keymap<VK, Vec<PaymentReferenceBalance>> = Keymap::new(b"VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP");
+// pub static VIEWING_KEY: Keymap<Index, VK> = Keymap::new(b"VIEWING_KEY");
+// pub static VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP: Keymap<VK, Vec<PaymentReferenceBalance>> = Keymap::new(b"VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP");
 
-pub type Index = String;
-// pub type ContractAddress = [u8; 32];
-pub type ResponseStatusCode = u16;
+// pub type Index = String;
+// // pub type ContractAddress = [u8; 32];
+// pub type ResponseStatusCode = u16;
 
-// reference: https://github.com/scrtlabs/examples/blob/master/secret-viewing-keys/secret-viewing-keys-contract/src/state.rs
-pub type VK = String; // Viewing Key
+// // reference: https://github.com/scrtlabs/examples/blob/master/secret-viewing-keys/secret-viewing-keys-contract/src/state.rs
+// pub type VK = String; // Viewing Key
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct State {
@@ -23,24 +23,24 @@ pub struct State {
     pub gateway_key: Binary,
 }
 
-// Secret contract keys
-// Reference: https://github.com/writersblockchain/aes-encrypt/blob/afa384d69aaddd92b50323fe1b9324f1342a5c0e/src/state.rs#L7
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
-pub struct MyKeys {
-    pub public_key: Vec<u8>,
-    pub private_key: Vec<u8>,
-}
+// // Secret contract keys
+// // Reference: https://github.com/writersblockchain/aes-encrypt/blob/afa384d69aaddd92b50323fe1b9324f1342a5c0e/src/state.rs#L7
+// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+// pub struct MyKeys {
+//     pub public_key: Vec<u8>,
+//     pub private_key: Vec<u8>,
+// }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct PaymentReferenceBalance {
-    pub payment_reference: String,
-    pub balance: Coin,
-}
+// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+// pub struct PaymentReferenceBalance {
+//     pub payment_reference: String,
+//     pub balance: Coin,
+// }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct PaymentReceipt {
-    pub payment_reference: String,
-    pub amount: Uint256,
-    pub denomination: String,
-    pub sig: Binary,
-}
+// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+// pub struct PaymentReceipt {
+//     pub payment_reference: String,
+//     pub amount: Uint256,
+//     pub denomination: String,
+//     pub sig: Binary,
+// }

--- a/packages/secret-contracts/nunya-contract/src/state.rs
+++ b/packages/secret-contracts/nunya-contract/src/state.rs
@@ -1,46 +1,46 @@
-use cosmwasm_std::{Addr, Binary, Coin, Uint256};
-use secret_toolkit::storage::{Item, Keymap};
+// use cosmwasm_std::{Addr, Binary, Coin, Uint256};
+// use secret_toolkit::storage::{Item, Keymap};
 
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+// use schemars::JsonSchema;
+// use serde::{Deserialize, Serialize};
 
-// pub static MY_KEYS: Item<MyKeys> = Item::new(b"my_keys");
-pub static CONFIG: Item<State> = Item::new(b"config");
-// pub static VIEWING_KEY: Keymap<Index, VK> = Keymap::new(b"VIEWING_KEY");
-// pub static VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP: Keymap<VK, Vec<PaymentReferenceBalance>> = Keymap::new(b"VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP");
+// // pub static MY_KEYS: Item<MyKeys> = Item::new(b"my_keys");
+// pub static CONFIG: Item<State> = Item::new(b"config");
+// // pub static VIEWING_KEY: Keymap<Index, VK> = Keymap::new(b"VIEWING_KEY");
+// // pub static VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP: Keymap<VK, Vec<PaymentReferenceBalance>> = Keymap::new(b"VIEWING_KEY_TO_PAYMENT_REF_TO_BALANCES_MAP");
 
-// pub type Index = String;
-// // pub type ContractAddress = [u8; 32];
-// pub type ResponseStatusCode = u16;
+// // pub type Index = String;
+// // // pub type ContractAddress = [u8; 32];
+// // pub type ResponseStatusCode = u16;
 
-// // reference: https://github.com/scrtlabs/examples/blob/master/secret-viewing-keys/secret-viewing-keys-contract/src/state.rs
-// pub type VK = String; // Viewing Key
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct State {
-    pub gateway_address: Addr,
-    pub gateway_hash: String,
-    pub gateway_key: Binary,
-}
-
-// // Secret contract keys
-// // Reference: https://github.com/writersblockchain/aes-encrypt/blob/afa384d69aaddd92b50323fe1b9324f1342a5c0e/src/state.rs#L7
-// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
-// pub struct MyKeys {
-//     pub public_key: Vec<u8>,
-//     pub private_key: Vec<u8>,
-// }
+// // // reference: https://github.com/scrtlabs/examples/blob/master/secret-viewing-keys/secret-viewing-keys-contract/src/state.rs
+// // pub type VK = String; // Viewing Key
 
 // #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-// pub struct PaymentReferenceBalance {
-//     pub payment_reference: String,
-//     pub balance: Coin,
+// pub struct State {
+//     pub gateway_address: Addr,
+//     pub gateway_hash: String,
+//     pub gateway_key: Binary,
 // }
 
-// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-// pub struct PaymentReceipt {
-//     pub payment_reference: String,
-//     pub amount: Uint256,
-//     pub denomination: String,
-//     pub sig: Binary,
-// }
+// // // Secret contract keys
+// // // Reference: https://github.com/writersblockchain/aes-encrypt/blob/afa384d69aaddd92b50323fe1b9324f1342a5c0e/src/state.rs#L7
+// // #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+// // pub struct MyKeys {
+// //     pub public_key: Vec<u8>,
+// //     pub private_key: Vec<u8>,
+// // }
+
+// // #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+// // pub struct PaymentReferenceBalance {
+// //     pub payment_reference: String,
+// //     pub balance: Coin,
+// // }
+
+// // #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+// // pub struct PaymentReceipt {
+// //     pub payment_reference: String,
+// //     pub amount: Uint256,
+// //     pub denomination: String,
+// //     pub sig: Binary,
+// // }

--- a/packages/secret-upload-contract/package.json
+++ b/packages/secret-upload-contract/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "./node_modules/.bin/tsc --build",
-    "clean": "./node_modules/.bin/tsc --clean",
+    "clean": "./node_modules/.bin/tsc --build --clean",
     "start": "yarn build && node ./dist/index.js"
   },
   "dependencies": {

--- a/packages/secret-upload-contract/src/index.ts
+++ b/packages/secret-upload-contract/src/index.ts
@@ -9,9 +9,10 @@ const walletOptions = {
   coinType: 529,
   bech32Prefix: 'secret',
 }
-console.log('process.env.WALLET_MNEMONIC_TESTNET', process.env.WALLET_MNEMONIC_TESTNET)
-// const wallet = new Wallet(process.env.WALLET_MNEMONIC_LOCAL, walletOptions);
-const wallet = new Wallet(process.env.WALLET_MNEMONIC_TESTNET, walletOptions);
+
+const wallet = new Wallet(process.env.WALLET_MNEMONIC_LOCAL, walletOptions);
+// console.log('process.env.WALLET_MNEMONIC_TESTNET', process.env.WALLET_MNEMONIC_TESTNET)
+// const wallet = new Wallet(process.env.WALLET_MNEMONIC_TESTNET, walletOptions);
 console.log('wallet: ', wallet);
 
 const rootPath = path.resolve(__dirname, '../../../'); // relative to ./dist
@@ -33,10 +34,10 @@ const gatewayPublicKeyBytes = Buffer.from(
 
 async function main () {
   const secretjs = new SecretNetworkClient({
-    // chainId: "secretdev-1",
-    // url: process.env.ENDPOINT_LOCAL || "",
-    chainId: "pulsar-3",
-    url: process.env.ENDPOINT_TESTNET || "",
+    chainId: "secretdev-1",
+    url: process.env.ENDPOINT_LOCAL || "",
+    // chainId: "pulsar-3",
+    // url: process.env.ENDPOINT_TESTNET || "",
     wallet: wallet,
     walletAddress: wallet.address,
   });
@@ -83,6 +84,7 @@ async function main () {
     } catch (e) {
       console.log('error: ', e);
     }
+    console.log('tx: ', JSON.stringify(tx, null, 2));
 
     codeId = String(
       tx?.arrayLog?.find((log: any) => log?.type === "message" && log?.key === "code_id")?.value


### PR DESCRIPTION
When i try uploading/deploying our Secret contract in /packages/secret-contracts/nunya-contract from here https://github.com/svub/nunya/pull/4 to Local Secret network https://docs.scrt.network/secret-network-documentation/development/readme-1/setting-up-your-environment#install-localsecret by running the command `cargo clean && AR=/opt/homebrew/opt/llvm/bin/llvm-ar CC=/opt/homebrew/opt/llvm/bin/clang RUSTFLAGS='-C link-arg=-s' cargo build --release --target wasm32-unknown-unknown`, i get the following error.

```
"rawLog": "failed to execute message; message index: 0: Execution error: Error during static Wasm validation: Wasm bytecode could not be deserialized. Deserialization error: \"Invalid table reference (128)\": create contract failed"
```

```
Error: {
  code: 3,
  message: 'type mismatch, parameter: code_id, error: strconv.ParseUint: parsing "undefined": invalid syntax',
  details: []
}
```

So I created this branch 'secret-contract-mods-strip-debug' where i stripped back the code until it finally deployed successfully after making the change in commit "[found issue, usage of use tnls](https://github.com/svub/nunya/commit/e93218ce5cc815aca96d09adb1e69e6bda22637b)".

The deployment error occurs because I'm importing `use tnls`. If I remove importing that it deploys successfully.

When it's building the logs output `secret_gateway v0.1.0 (https://github.com/SecretSaturn/TNLS?branch=main#828496d7`, which appears to be this commit https://github.com/SecretSaturn/SecretPath/commit/828496d7, but that isn't the latest commit.
In the Cargo.toml file it imports `tnls = { git = "https://github.com/SecretSaturn/TNLS", branch = "main", package = "secret_gateway", default-features = false }` without specifying the version, so I thought it'd get the latest commit.

But in the Cargo.lock file it shows it uses:
```
[[package]]
name = "secret_gateway"
version = "0.1.0"
source = "git+https://github.com/SecretSaturn/TNLS?branch=main#828496d76e5e94958fb1eecb52d51ce928ac5105"
...
```

But the use of `use tnls` is because our project was based on the contracts 'secretpath-voting' from https://github.com/SecretFoundation/Secretpath-tutorials/tree/master/secretpath-voting, and I tried deploying them and they got the same deployment error.

So I tried deleting the Cargo.lock file so it wouldn't be stuck using that old commit 828496d76e5e94958fb1eecb52d51ce928ac5105 in the 'main' branch of https://github.com/SecretSaturn/TNLS.

Then when I built it again with `cargo clean && AR=/opt/homebrew/opt/llvm/bin/llvm-ar CC=/opt/homebrew/opt/llvm/bin/clang RUSTFLAGS='-C link-arg=-s' cargo build --release --target wasm32-unknown-unknown` it used the latest commit e9865394 from the 'main' branch of https://github.com/SecretSaturn/TNLS since the logs displayed:
```
version Compiling secret_gateway v0.1.0 (https://github.com/SecretSaturn/TNLS?branch=main#e9865394)
```

But even with that latest version it still output the same deployment error `code: 3`
